### PR TITLE
Scatter render optimization

### DIFF
--- a/demos/WinFormsDemos/FormMain.cs
+++ b/demos/WinFormsDemos/FormMain.cs
@@ -29,7 +29,7 @@ namespace WinFormsDemos
             interactivePlot1.figure.Subplot(3, 2, 2);
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Sin(50));
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Cos(50));
-            int n = 10_000;
+            int n = 5000;
             interactivePlot1.figure.Subplot(3, 2, 3, colSpan: 2);
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 0));
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 1));

--- a/demos/WinFormsDemos/FormMain.cs
+++ b/demos/WinFormsDemos/FormMain.cs
@@ -20,6 +20,8 @@ namespace WinFormsDemos
 
         public void DemoLayout()
         {
+            int CenterSubplotPointsCount = 1000;
+
             interactivePlot1.figure.Clear();
 
             interactivePlot1.figure.Subplot(3, 2, 1);
@@ -29,10 +31,13 @@ namespace WinFormsDemos
             interactivePlot1.figure.Subplot(3, 2, 2);
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Sin(50));
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Cos(50));
-            int n = 5000;
+
             interactivePlot1.figure.Subplot(3, 2, 3, colSpan: 2);
-            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 0));
-            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 1));
+            double[] x = QuickPlot.Generate.Consecutative(CenterSubplotPointsCount);
+            double[] y1 = QuickPlot.Generate.Random(CenterSubplotPointsCount, seed: 0);
+            double[] y2 = QuickPlot.Generate.Random(CenterSubplotPointsCount, seed: 1);
+            interactivePlot1.figure.plot.Scatter(x, y1);
+            interactivePlot1.figure.plot.Scatter(x, y2);
 
             interactivePlot1.figure.Subplot(3, 2, 5);
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(20), QuickPlot.Generate.Sin(20));

--- a/demos/WinFormsDemos/FormMain.cs
+++ b/demos/WinFormsDemos/FormMain.cs
@@ -29,10 +29,10 @@ namespace WinFormsDemos
             interactivePlot1.figure.Subplot(3, 2, 2);
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Sin(50));
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Cos(50));
-
+            int n = 10_000;
             interactivePlot1.figure.Subplot(3, 2, 3, colSpan: 2);
-            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Random(50, seed: 0));
-            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Random(50, seed: 1));
+            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 0));
+            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 1));
 
             interactivePlot1.figure.Subplot(3, 2, 5);
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(20), QuickPlot.Generate.Sin(20));

--- a/src/QuickPlot/Plot.cs
+++ b/src/QuickPlot/Plot.cs
@@ -111,8 +111,14 @@ namespace QuickPlot
             yTicks.Render(canvas, axes);
             xTicks.Render(canvas, axes);
 
+
+            canvas.Save();
+            canvas.ClipRect(axes.GetDataRect());
+
             for (int i = 0; i < plottables.Count; i++)
                 plottables[i].Render(canvas, axes);
+            
+            canvas.Restore();
 
             //RenderLayoutDebug(canvas);
             RenderLabels(canvas);

--- a/src/QuickPlot/Plottables/Scatter.cs
+++ b/src/QuickPlot/Plottables/Scatter.cs
@@ -57,9 +57,8 @@ namespace QuickPlot.Plottables
                     SKPoint pt = axes.GetPixel(xs[i], ys[i]);
                     markerPath.AddCircle(pt.X, pt.Y, 3);
                 }
-
-                // using fill style produce memory leak's Stroke style works, but looks bad
-                //style.paint.Style = SKPaintStyle.Fill;
+                
+                style.paint.Style = SKPaintStyle.Fill;
 
                 canvas.DrawPath(markerPath, style.paint);
             }            

--- a/src/QuickPlot/Plottables/Scatter.cs
+++ b/src/QuickPlot/Plottables/Scatter.cs
@@ -41,29 +41,31 @@ namespace QuickPlot.Plottables
             canvas.Save();
             canvas.ClipRect(axes.GetDataRect());
 
-            // draw lines
-            for (int i = 1; i < xs.Length; i++)
+            using (SKPath linePath = new SKPath())
             {
-                SKPoint pt1 = axes.GetPixel(xs[i - 1], ys[i - 1]);
-                SKPoint pt2 = axes.GetPixel(xs[i], ys[i]);
-
-                try
+                linePath.MoveTo(axes.GetPixel(xs[0], ys[0]));
+                // draw lines
+                for (int i = 1; i < xs.Length; i++)
                 {
-                    canvas.DrawLine(pt1, pt2, style.paint);
+                    linePath.LineTo(axes.GetPixel(xs[i], ys[i]));
                 }
-                catch
-                {
-                    Debug.WriteLine($"scatter crashed drawing line {i}");
-                }
+                style.paint.Style = SKPaintStyle.Stroke;
+                canvas.DrawPath(linePath, style.paint);
             }
-
             // draw markers
-            for (int i = 0; i < xs.Length; i++)
+            using (SKPath markerPath = new SKPath())
             {
-                SKPoint pt = axes.GetPixel(xs[i], ys[i]);
-                canvas.DrawCircle(pt, 3, style.paint);
-            }
+                for (int i = 0; i < xs.Length; i++)
+                {
+                    SKPoint pt = axes.GetPixel(xs[i], ys[i]);
+                    markerPath.AddCircle(pt.X, pt.Y, 3);
+                }
 
+                // using fill style produce memory leak's Stroke style works, but looks bad
+                //style.paint.Style = SKPaintStyle.Fill;
+
+                canvas.DrawPath(markerPath, style.paint);
+            }
             canvas.Restore();
         }
     }

--- a/src/QuickPlot/Plottables/Scatter.cs
+++ b/src/QuickPlot/Plottables/Scatter.cs
@@ -37,10 +37,7 @@ namespace QuickPlot.Plottables
         }
 
         public override void Render(SKCanvas canvas, PlotSettings.Axes axes)
-        {
-            canvas.Save();
-            canvas.ClipRect(axes.GetDataRect());
-
+        {           
             using (SKPath linePath = new SKPath())
             {
                 linePath.MoveTo(axes.GetPixel(xs[0], ys[0]));
@@ -65,8 +62,7 @@ namespace QuickPlot.Plottables
                 //style.paint.Style = SKPaintStyle.Fill;
 
                 canvas.DrawPath(markerPath, style.paint);
-            }
-            canvas.Restore();
+            }            
         }
     }
 }


### PR DESCRIPTION
Optimize Skia render calls count by using SKPath.
This significant improve performance 4000 lines works fast.
`Fill` style for markers significant increace memory usage (for some way of caching, no memory leaks):  
- 2 GB for 2 x 2000 points scatter with `Filled` circles markers and grows linear.
- 100-140 MB for 2 x (2000 - 5000) points scatter with `Stroke` circles markers

Way to improve memory usage - set `Stroke` style for markers. Will it realy need draw scatters more then 10000 points?

ClipRect moves outside plottables. Small performance improvement.