### PR TITLE
Redraw only needed subplots

### DIFF
--- a/demos/WinFormsDemos/FormMain.cs
+++ b/demos/WinFormsDemos/FormMain.cs
@@ -30,9 +30,10 @@ namespace WinFormsDemos
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Sin(50));
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Cos(50));
 
+            int n = 5000;
             interactivePlot1.figure.Subplot(3, 2, 3, colSpan: 2);
-            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Random(50, seed: 0));
-            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(50), QuickPlot.Generate.Random(50, seed: 1));
+            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 0));
+            interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(n), QuickPlot.Generate.Random(n, seed: 1));
 
             interactivePlot1.figure.Subplot(3, 2, 5);
             interactivePlot1.figure.plot.Scatter(QuickPlot.Generate.Consecutative(20), QuickPlot.Generate.Sin(20));

--- a/src/QuickPlot.WinForms/InteractivePlot.cs
+++ b/src/QuickPlot.WinForms/InteractivePlot.cs
@@ -96,7 +96,7 @@ namespace QuickPlot.WinForms
                 surface = SKSurface.Create(context, renderTarget, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
             }
 
-            figure.Render(surface.Canvas, figureSize);
+            figure.Render(surface.Canvas, figureSize, new SKRect(e.ClipRectangle.Left, e.ClipRectangle.Top, e.ClipRectangle.Right, e.ClipRectangle.Bottom));
 
             surface.Canvas.Flush();
             glControl1.SwapBuffers();
@@ -140,7 +140,8 @@ namespace QuickPlot.WinForms
                 if (e.Button == MouseButtons.Middle)
                 {
                     plotEngagedWithMouse.AutoAxis();
-                    glControl1.Refresh();
+                    var redrawRect = plotEngagedWithMouse.layout.plotRect;
+                    glControl1.Invalidate(new Rectangle((int)redrawRect.Left, (int)redrawRect.Top, (int)redrawRect.Width, (int)redrawRect.Height));
                 }
                 plotEngagedWithMouse = null;
             }
@@ -152,7 +153,8 @@ namespace QuickPlot.WinForms
             if (plotEngagedWithMouse != null)
             {
                 plotEngagedWithMouse.MouseMove(mousePoint);
-                glControl1.Refresh();
+                var redrawRect = plotEngagedWithMouse.layout.plotRect;
+                glControl1.Invalidate(new Rectangle((int)redrawRect.Left, (int)redrawRect.Top, (int)redrawRect.Width, (int)redrawRect.Height));
             }
             else
             {
@@ -165,8 +167,13 @@ namespace QuickPlot.WinForms
         {
             var mousePoint = new SKPoint(e.Location.X, e.Location.Y);
             double zoom = (e.Delta > 0) ? 1.15 : 0.85;
-            figure.PlotUnderMouse(figureSize, mousePoint)?.axes.Zoom(zoom, zoom);
-            glControl1.Refresh();
+            var subplot = figure.PlotUnderMouse(figureSize, mousePoint);
+            if (subplot != null)
+            {
+                subplot.axes.Zoom(zoom, zoom);
+                var redrawRect = subplot.layout.plotRect;
+                glControl1.Invalidate(new Rectangle((int)redrawRect.Left, (int)redrawRect.Top, (int)redrawRect.Width, (int)redrawRect.Height));
+            }
         }
 
         #endregion

--- a/src/QuickPlot/Figure.cs
+++ b/src/QuickPlot/Figure.cs
@@ -56,14 +56,27 @@ namespace QuickPlot
         #region rendering
 
         private Stopwatch stopwatchRender = Stopwatch.StartNew();
-        public void Render(SKCanvas canvas, SKSize figureSize)
+        public void Render(SKCanvas canvas, SKSize figureSize, SKRect clipRectangle = new SKRect())
         {
             stopwatchRender.Restart();
+            var fillPaint = new SKPaint();
+            fillPaint.Color = backgroundColor;
 
             Console.WriteLine();
-            canvas.Clear(backgroundColor);
             foreach (Plot subplot in subplots)
-                subplot.Render(canvas, SubplotRect(figureSize, subplot));
+            {
+                var subplotRect = SubplotRect(figureSize, subplot);
+
+                // Redraw only subplots what affected by clipRect
+                // if clipRect not specified redraw all supbplots
+                if (clipRectangle.IsEmpty || clipRectangle.Contains(subplotRect) || clipRectangle.IntersectsWith(subplotRect))
+                {
+                    SKRect renderArea = subplot.subplotPosition.GetRectangle(figureSize);
+                    // Clear subplot area
+                    canvas.DrawRect(renderArea, fillPaint);
+                    subplot.Render(canvas, subplotRect);
+                };
+            };
 
             stopwatchRender.Stop();
         }


### PR DESCRIPTION
Rerender only subplot which user interact. #4.
Also Rerender only subplot needed to invalidate by OS calls -   Quick plot window part unhide from other window.
Possible negative sides of this feature - In some scenarios with auto update Plots data, not user active plot stay static. This can be solved with manualy call `Figure.Render()` without `clipRect` param. This call redraw all subplots.