### PR TITLE
Generate Class, added tests and refactoring.

### DIFF
--- a/src/QuickPlot.Tests/GenerateTests.cs
+++ b/src/QuickPlot.Tests/GenerateTests.cs
@@ -41,7 +41,7 @@ namespace QuickPlot.Tests.NUnitTests
         {
             var result = Generate.Random(50, 5, 3);
 
-            Assert.That(!result.Any(x => x < 3 || x > 3 + 5 ));
+            Assert.That(!result.Any(x => x < 3 || x > 3 + 5));
         }
 
         [Test]
@@ -60,6 +60,55 @@ namespace QuickPlot.Tests.NUnitTests
             var result2 = Generate.Random(50, 12, 7);
 
             Assert.AreNotEqual(result1, result2);
+        }
+        [Test]
+        public void Consecutative_ZeroCount_ReturnsEmptyArray()
+        {
+            double[] result = Generate.Consecutative(0);
+            Assert.IsEmpty(result);
+        }
+        [Test]
+        public void Consecutative_ZeroCountSomeParams_ReturnsEmptyArray()
+        {
+            double[] result = Generate.Consecutative(0, 3, 15);
+            Assert.IsEmpty(result);
+        }
+        [Test]
+        public void Consecutative_NegativeCount_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Generate.Consecutative(-5, 7, 21));
+        }
+
+        [TestCase(5)]
+        [TestCase(9)]
+        [TestCase(42)]
+        [TestCase(7)]
+        public void Consecutative_SmallCounts_ArraySizeEqualCount(int count)
+        {
+            var result = Generate.Consecutative(count, 6, 12);
+            Assert.AreEqual(count, result.Length);
+        }
+        [Test]
+        public void Consecutative_TenPrecalcNumbers_GenerateCorrect()
+        {
+            double[] expected = new double[10] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var result = Generate.Consecutative(10, 1, 0);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Consecutative_TenPrecalcNumbersWithOffset_GenerateCorrect()
+        {
+            double[] expected = new double[10] { 2, 4, 6, 8, 10, 12, 14, 16, 18, 20 };
+            var result = Generate.Consecutative(10, 2, 2);
+            Assert.AreEqual(expected, result);
+        }
+        [Test]
+        public void Consecutative_TenPrecalcNumbersReverce_GenerateCorrect()
+        {
+            double[] expected = new double[10] { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+            var result = Generate.Consecutative(10, -1, 10);
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/src/QuickPlot.Tests/GenerateTests.cs
+++ b/src/QuickPlot.Tests/GenerateTests.cs
@@ -110,5 +110,80 @@ namespace QuickPlot.Tests.NUnitTests
             var result = Generate.Consecutative(10, -1, 10);
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        public void Sin_ZeroCount_ReturnEmptyArray()
+        {
+            double[] result = Generate.Sin(0);
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Sin_ZeroCountSomeParams_ReturnEmptyArray()
+        {
+            double[] result = Generate.Sin(0, 12, 2, 4, 5);
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Sin_NegativeCount_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Generate.Sin(-7, 32, 15, 6, 2));
+        }
+
+        [TestCase(5)]
+        [TestCase(9)]
+        [TestCase(42)]
+        [TestCase(7)]
+        public void Sin_SmallCounts_ArraySizeEqualCount(int count)
+        {
+            var result = Generate.Sin(count, 6, 12, 5, 3);
+            Assert.AreEqual(count, result.Length);
+        }
+
+        [TestCase(1, 5, 12)]
+        [TestCase(15, 7, 32)]
+        [TestCase(0, 3, 1)]
+        [TestCase(3, 3, 3)]
+        public void Sin_1PointZeroPhase_AlwaysEqualOffset(double oscillations, double offset, double mult)
+        {
+            double[] result = Generate.Sin(1, oscillations, offset, mult, 0);
+            Assert.AreEqual(offset, result[0]);
+        }
+
+        [Test]
+        public void Sin_5pointsManualCalc_GenerateCorrect()
+        {
+            double[] expected = new double[] { 0, 1, 0, -1, 0 };
+            var result = Generate.Sin(5, 1, 0, 1, 0);
+            Assert.That(result, Is.EqualTo(expected).Within(0.0001));
+        }
+
+        [Test]
+        public void Sin_5pointsWithOffsetManualCalc_GenerateCorrect()
+        {
+            double[] expected = new double[] { 1, 2, 1, 0, 1 };
+            var result = Generate.Sin(5, 1, 1, 1, 0);
+            Assert.That(result, Is.EqualTo(expected).Within(0.0001));
+        }
+
+        [Test]
+        public void Sin_9PointsManualCalc_GenerateCorrect()
+        {
+            double[] expected = new double[] { 0, 1, 0, -1, 0, 1, 0, -1, 0 };
+            var result = Generate.Sin(9, 2, 0, 1, 0);
+            Assert.That(result, Is.EqualTo(expected).Within(0.0001));
+        }
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(15)]
+        [TestCase(21)]
+        public void Sin_ShiftByInteger_GenerateEqualResult(int shift)
+        {
+            double[] expected = new double[] { 0, 1, 0, -1, 0, 1, 0, -1, 0 };
+            var result = Generate.Sin(20, 5, 12, 3, 0);
+            var resultWithShift = Generate.Sin(20, 5, 12, 3, shift);
+            Assert.That(result, Is.EqualTo(resultWithShift).Within(0.0001));
+        }
     }
 }

--- a/src/QuickPlot.Tests/GenerateTests.cs
+++ b/src/QuickPlot.Tests/GenerateTests.cs
@@ -261,5 +261,13 @@ namespace QuickPlot.Tests.NUnitTests
             var resultWithShift = Generate.Cos(20, 5, 12, 3, shift);
             Assert.That(result, Is.EqualTo(resultWithShift).Within(0.0001));
         }
+
+        [Test]
+        public void Cos_SomeCos_EqualtoSinWithquaterShift()
+        {
+            double[] resultCos = Generate.Cos(100, 5, 12, 3, 0);
+            double[] resultSin = Generate.Sin(100, 5, 12, 3, 0.25);
+            Assert.That(resultSin, Is.EqualTo(resultCos).Within(0.0001));
+        }
     }
 }

--- a/src/QuickPlot.Tests/GenerateTests.cs
+++ b/src/QuickPlot.Tests/GenerateTests.cs
@@ -145,7 +145,7 @@ namespace QuickPlot.Tests.NUnitTests
         [TestCase(15, 7, 32)]
         [TestCase(0, 3, 1)]
         [TestCase(3, 3, 3)]
-        public void Sin_1PointZeroPhase_AlwaysEqualOffset(double oscillations, double offset, double mult)
+        public void Sin_1PointZeroShift_AlwaysEqualOffset(double oscillations, double offset, double mult)
         {
             double[] result = Generate.Sin(1, oscillations, offset, mult, 0);
             Assert.AreEqual(offset, result[0]);
@@ -183,6 +183,82 @@ namespace QuickPlot.Tests.NUnitTests
             double[] expected = new double[] { 0, 1, 0, -1, 0, 1, 0, -1, 0 };
             var result = Generate.Sin(20, 5, 12, 3, 0);
             var resultWithShift = Generate.Sin(20, 5, 12, 3, shift);
+            Assert.That(result, Is.EqualTo(resultWithShift).Within(0.0001));
+        }
+
+        [Test]
+        public void Cos_ZeroCount_ReturnEmptyArray()
+        {
+            double[] result = Generate.Cos(0);
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Cos_ZeroCountSomeParams_ReturnEmptyArray()
+        {
+            double[] result = Generate.Cos(0, 12, 2, 4, 5);
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Cos_NegativeCount_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Generate.Cos(-7, 32, 15, 6, 2));
+        }
+
+        [TestCase(5)]
+        [TestCase(9)]
+        [TestCase(42)]
+        [TestCase(7)]
+        public void Cos_SmallCounts_ArraySizeEqualCount(int count)
+        {
+            var result = Generate.Cos(count, 6, 12, 5, 3);
+            Assert.AreEqual(count, result.Length);
+        }
+
+        [TestCase(1, 5, 12)]
+        [TestCase(15, 7, 32)]
+        [TestCase(0, 3, 1)]
+        [TestCase(3, 3, 3)]
+        public void Cos_1PointZeroShift_AlwaysEqualOffsetPlusMult(double oscillations, double offset, double mult)
+        {
+            double[] result = Generate.Cos(1, oscillations, offset, mult, 0);
+            Assert.AreEqual(offset + mult, result[0]);
+        }
+
+
+        [Test]
+        public void Cos_5pointsManualCalc_GenerateCorrect()
+        {
+            double[] expected = new double[] { 1, 0, -1, 0, 1 };
+            var result = Generate.Cos(5, 1, 0, 1, 0);
+            Assert.That(result, Is.EqualTo(expected).Within(0.0001));
+        }
+
+        [Test]
+        public void Cos_5pointsWithOffsetManualCalc_GenerateCorrect()
+        {
+            double[] expected = new double[] { 2, 1, 0, 1, 2 };
+            var result = Generate.Cos(5, 1, 1, 1, 0);
+            Assert.That(result, Is.EqualTo(expected).Within(0.0001));
+        }
+
+        [Test]
+        public void Cos_9PointsManualCalc_GenerateCorrect()
+        {
+            double[] expected = new double[] { 1, 0, -1, 0, 1, 0, -1, 0, 1 };
+            var result = Generate.Cos(9, 2, 0, 1, 0);
+            Assert.That(result, Is.EqualTo(expected).Within(0.0001));
+        }
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(15)]
+        [TestCase(21)]
+        public void Cos_ShiftByInteger_GenerateEqualResult(int shift)
+        {
+            double[] expected = new double[] { 0, 1, 0, -1, 0, 1, 0, -1, 0 };
+            var result = Generate.Cos(20, 5, 12, 3, 0);
+            var resultWithShift = Generate.Cos(20, 5, 12, 3, shift);
             Assert.That(result, Is.EqualTo(resultWithShift).Within(0.0001));
         }
     }

--- a/src/QuickPlot/Generate.cs
+++ b/src/QuickPlot/Generate.cs
@@ -25,10 +25,9 @@ namespace QuickPlot
 
         public static double[] Consecutative(int count, double mult = 1, double offset = 0)
         {
-            double[] values = new double[count];
-            for (int i = 0; i < values.Length; i++)
-                values[i] = i * mult + offset;
-            return values;
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count can't be negative");
+            return Enumerable.Range(0, count).Select(x => (double)x * mult + offset).ToArray();
         }
 
         public static double[] Sin(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double phase = 0)

--- a/src/QuickPlot/Generate.cs
+++ b/src/QuickPlot/Generate.cs
@@ -30,13 +30,19 @@ namespace QuickPlot
             return Enumerable.Range(0, count).Select(x => (double)x * mult + offset).ToArray();
         }
 
-        public static double[] Sin(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double phase = 0)
+        public static double[] Sin(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double shiftOscillations = 0)
         {
-            double sinScale = 2 * Math.PI * oscillations / pointCount;
-            double[] ys = new double[pointCount];
-            for (int i = 0; i < ys.Length; i++)
-                ys[i] = Math.Sin(i * sinScale + phase * Math.PI * 2) * mult + offset;
-            return ys;
+
+            if (pointCount < 0)
+                throw new ArgumentOutOfRangeException("pointCount can't be nagative");
+            double sinScale = 1;
+            if (pointCount > 1)
+                sinScale = 2 * Math.PI * oscillations / (pointCount - 1);
+            else
+                sinScale = 1;
+            return Enumerable.Range(0, pointCount)
+                .Select(x => mult * Math.Sin(sinScale * x + shiftOscillations * Math.PI * 2) + offset)
+                .ToArray();
         }
 
         public static double[] Cos(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double phase = 0)

--- a/src/QuickPlot/Generate.cs
+++ b/src/QuickPlot/Generate.cs
@@ -46,16 +46,7 @@ namespace QuickPlot
 
         public static double[] Cos(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double shiftOscillations = 0)
         {
-            if (pointCount < 0)
-                throw new ArgumentOutOfRangeException("pointCount can't be negative");
-            double cosScale = 1;
-            if (pointCount > 1)
-                cosScale = 2 * Math.PI * oscillations / (pointCount - 1);
-            else
-                cosScale = 1;
-            return Enumerable.Range(0, pointCount)
-                .Select(x => mult * Math.Cos(cosScale * x + shiftOscillations * Math.PI * 2) + offset)
-                .ToArray();
+            return Sin(pointCount, oscillations, offset, mult, shiftOscillations + 0.25);
         }
     }
 }

--- a/src/QuickPlot/Generate.cs
+++ b/src/QuickPlot/Generate.cs
@@ -32,9 +32,8 @@ namespace QuickPlot
 
         public static double[] Sin(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double shiftOscillations = 0)
         {
-
             if (pointCount < 0)
-                throw new ArgumentOutOfRangeException("pointCount can't be nagative");
+                throw new ArgumentOutOfRangeException("pointCount can't be negative");
             double sinScale = 1;
             if (pointCount > 1)
                 sinScale = 2 * Math.PI * oscillations / (pointCount - 1);
@@ -45,13 +44,18 @@ namespace QuickPlot
                 .ToArray();
         }
 
-        public static double[] Cos(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double phase = 0)
+        public static double[] Cos(int pointCount, double oscillations = 1, double offset = 0, double mult = 1, double shiftOscillations = 0)
         {
-            double sinScale = 2 * Math.PI * oscillations / pointCount;
-            double[] ys = new double[pointCount];
-            for (int i = 0; i < ys.Length; i++)
-                ys[i] = Math.Cos(i * sinScale + phase * Math.PI * 2) * mult + offset;
-            return ys;
+            if (pointCount < 0)
+                throw new ArgumentOutOfRangeException("pointCount can't be negative");
+            double cosScale = 1;
+            if (pointCount > 1)
+                cosScale = 2 * Math.PI * oscillations / (pointCount - 1);
+            else
+                cosScale = 1;
+            return Enumerable.Range(0, pointCount)
+                .Select(x => mult * Math.Cos(cosScale * x + shiftOscillations * Math.PI * 2) + offset)
+                .ToArray();
         }
     }
 }


### PR DESCRIPTION
Changed behavior:
- Sin/Cos last point now equal to start point(bit lowered frequency).
- `phase` param name changed to `shiftOscilations` (phase name confuse, because it actual phase/(2*PI))
- Cos depends on Sin, use it implementation.
 