### PR TITLE
Fix wrong divisions index, during decreace, Refactor.

### DIFF
--- a/src/QuickPlot/PlotSettings/TickCollection.cs
+++ b/src/QuickPlot/PlotSettings/TickCollection.cs
@@ -62,8 +62,8 @@ namespace QuickPlot.PlotSettings
 
         public void DecreaseDensity(double low, double high)
         {
-            spacing *= divBy[divisions % divBy.Length];
             divisions = (divisions == 0) ? divBy.Length - 1 : divisions - 1;
+            spacing *= divBy[divisions % divBy.Length];            
             double offset = Math.Abs(low % spacing);
             firstTick = (low < 0) ? low + offset : low - offset;
         }

--- a/src/QuickPlot/PlotSettings/TickCollection.cs
+++ b/src/QuickPlot/PlotSettings/TickCollection.cs
@@ -55,17 +55,20 @@ namespace QuickPlot.PlotSettings
         public void IncreaseDensity(double low, double high)
         {
             spacing /= divBy[divisions % divBy.Length];
-            divisions += 1;
-            double offset = Math.Abs(low % spacing);
-            firstTick = (low < 0) ? low + offset : low - offset;
+            divisions++;
+            double offset = low % spacing;
+            firstTick = low - offset;
         }
 
         public void DecreaseDensity(double low, double high)
         {
-            divisions = (divisions == 0) ? divBy.Length - 1 : divisions - 1;
+            divisions--;
+            if ( divisions < 0 )
+                divisions += divBy.Length;
+            
             spacing *= divBy[divisions % divBy.Length];            
-            double offset = Math.Abs(low % spacing);
-            firstTick = (low < 0) ? low + offset : low - offset;
+            double offset = low % spacing;
+            firstTick = low - offset;
         }
     }
 


### PR DESCRIPTION
Additional refactored TIckSpacing class.

Decreacing with wrong index resulting wrong tick spacing not 10, 5, 2.5, 1 etc.
`QuickPlot.Demos.Winforms` after launching have (0.625, - 0.625) tick values without this fix.
